### PR TITLE
Add string fields for core long fields.

### DIFF
--- a/twitter4j-appengine/src/main/java/twitter4j/LazyStatus.java
+++ b/twitter4j-appengine/src/main/java/twitter4j/LazyStatus.java
@@ -16,8 +16,9 @@
 
 package twitter4j;
 
-import javax.annotation.Generated;
 import java.util.Date;
+
+import javax.annotation.Generated;
 
 /**
  * A data class representing one single status of a user.
@@ -69,6 +70,10 @@ final class LazyStatus implements twitter4j.Status {
      */
     public long getId() {
         return getTarget().getId();
+    }
+
+    public String getIdString() {
+        return getTarget().getIdString();
     }
 
 
@@ -123,6 +128,10 @@ final class LazyStatus implements twitter4j.Status {
         return getTarget().getInReplyToStatusId();
     }
 
+    public String getInReplyToStatusIdString() {
+        return getTarget().getInReplyToStatusIdString();
+    }
+
 
     /**
      * Returns the in_reply_user_id
@@ -132,6 +141,10 @@ final class LazyStatus implements twitter4j.Status {
      */
     public long getInReplyToUserId() {
         return getTarget().getInReplyToUserId();
+    }
+
+    public String getInReplyToUserIdString() {
+        return getTarget().getInReplyToUserIdString();
     }
 
 
@@ -268,6 +281,10 @@ final class LazyStatus implements twitter4j.Status {
         return getTarget().getCurrentUserRetweetId();
     }
 
+    public String getCurrentUserRetweetIdString() {
+        return getTarget().getCurrentUserRetweetIdString();
+    }
+
     @Override
     public boolean isPossiblySensitive() {
         return getTarget().isPossiblySensitive();
@@ -339,6 +356,10 @@ final class LazyStatus implements twitter4j.Status {
     @Override
     public long getQuotedStatusId() {
         return getTarget().getQuotedStatusId();
+    }
+
+    public String getQuotedStatusIdString() {
+        return getTarget().getQuotedStatusIdString();
     }
 
     @Override

--- a/twitter4j-appengine/src/main/java/twitter4j/LazyUser.java
+++ b/twitter4j-appengine/src/main/java/twitter4j/LazyUser.java
@@ -16,10 +16,11 @@
 
 package twitter4j;
 
-import twitter4j.conf.Configuration;
+import java.util.Date;
 
 import javax.annotation.Generated;
-import java.util.Date;
+
+import twitter4j.conf.Configuration;
 
 /**
  * A data class representing Basic user information element
@@ -59,6 +60,10 @@ final class LazyUser implements twitter4j.User {
      */
     public long getId() {
         return getTarget().getId();
+    }
+
+    public String getIdString() {
+        return getTarget().getIdString();
     }
 
 

--- a/twitter4j-core/src/internal-json/java/twitter4j/StatusJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/StatusJSONImpl.java
@@ -339,7 +339,7 @@ import twitter4j.conf.Configuration;
 
     @Override
     public String getInReplyToStatusIdString() {
-        return Objects.toString(getInReplyToStatusIdString(), "");
+        return Objects.toString(getInReplyToStatusId(), "");
     }
 
     @Override
@@ -349,7 +349,7 @@ import twitter4j.conf.Configuration;
 
     @Override
     public String getInReplyToUserIdString() {
-        return Objects.toString(getInReplyToUserIdString(), "");
+        return Objects.toString(getInReplyToUserId(), "");
     }
 
     @Override
@@ -419,7 +419,7 @@ import twitter4j.conf.Configuration;
 
     @Override
     public String getCurrentUserRetweetIdString() {
-        return Objects.toString(getCurrentUserRetweetIdString(), "");
+        return Objects.toString(getCurrentUserRetweetId(), "");
     }
 
     @Override
@@ -469,7 +469,7 @@ import twitter4j.conf.Configuration;
 
     @Override
     public String getQuotedStatusIdString() {
-        return Objects.toString(getQuotedStatusIdString(), "");
+        return Objects.toString(getQuotedStatusId(), "");
     }
 
     @Override

--- a/twitter4j-core/src/internal-json/java/twitter4j/StatusJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/StatusJSONImpl.java
@@ -16,12 +16,12 @@
 
 package twitter4j;
 
-import twitter4j.conf.Configuration;
+import static twitter4j.ParseUtil.getDate;
 
 import java.util.Arrays;
 import java.util.Date;
 
-import static twitter4j.ParseUtil.getDate;
+import twitter4j.conf.Configuration;
 
 /**
  * A data class representing one single status of a user.
@@ -34,13 +34,16 @@ import static twitter4j.ParseUtil.getDate;
 
     private Date createdAt;
     private long id;
+    private String idString;
     private String text;
     private int displayTextRangeStart = -1;
     private int displayTextRangeEnd = -1;
     private String source;
     private boolean isTruncated;
     private long inReplyToStatusId;
+    private String inReplyToStatusIdString;
     private long inReplyToUserId;
+    private String inReplyToUserIdString;
     private boolean isFavorited;
     private boolean isRetweeted;
     private int favoriteCount;
@@ -61,11 +64,13 @@ import static twitter4j.ParseUtil.getDate;
     private MediaEntity[] mediaEntities;
     private SymbolEntity[] symbolEntities;
     private long currentUserRetweetId = -1L;
+    private String currentUserRetweetIdString = "-1";
     private Scopes scopes;
     private User user = null;
     private String[] withheldInCountries = null;
     private Status quotedStatus;
     private long quotedStatusId = -1L;
+    private String quotedStatusIdString = "-1";
 
     /*package*/StatusJSONImpl(HttpResponse res, Configuration conf) throws TwitterException {
         super(res);
@@ -97,11 +102,14 @@ import static twitter4j.ParseUtil.getDate;
 
     private void init(JSONObject json) throws TwitterException {
         id = ParseUtil.getLong("id", json);
+        idString = ParseUtil.getUnescapedString("id", json);
         source = ParseUtil.getUnescapedString("source", json);
         createdAt = getDate("created_at", json);
         isTruncated = ParseUtil.getBoolean("truncated", json);
         inReplyToStatusId = ParseUtil.getLong("in_reply_to_status_id", json);
+        inReplyToStatusIdString = ParseUtil.getUnescapedString("in_reply_to_status_id", json);
         inReplyToUserId = ParseUtil.getLong("in_reply_to_user_id", json);
+        inReplyToUserIdString = ParseUtil.getUnescapedString("in_reply_to_user_id", json);
         isFavorited = ParseUtil.getBoolean("favorited", json);
         isRetweeted = ParseUtil.getBoolean("retweeted", json);
         inReplyToScreenName = ParseUtil.getUnescapedString("in_reply_to_screen_name", json);
@@ -137,6 +145,7 @@ import static twitter4j.ParseUtil.getDate;
             }
             if (!json.isNull("quoted_status_id")) {
                 quotedStatusId = ParseUtil.getLong("quoted_status_id", json);
+                quotedStatusIdString = ParseUtil.getUnescapedString("quoted_status_id", json);
             }
             if (!json.isNull("display_text_range")) {
                 JSONArray indicesArray = json.getJSONArray("display_text_range");
@@ -164,6 +173,7 @@ import static twitter4j.ParseUtil.getDate;
 
             if (!json.isNull("current_user_retweet")) {
                 currentUserRetweetId = json.getJSONObject("current_user_retweet").getLong("id");
+                currentUserRetweetIdString = json.getJSONObject("current_user_retweet").getString("id");
             }
             if (!json.isNull("lang")) {
                 lang = ParseUtil.getUnescapedString("lang", json);
@@ -300,6 +310,10 @@ import static twitter4j.ParseUtil.getDate;
         return this.id;
     }
 
+    public String getIdString() {
+        return this.idString;
+    }
+
     @Override
     public String getText() {
         return this.text;
@@ -332,8 +346,18 @@ import static twitter4j.ParseUtil.getDate;
     }
 
     @Override
+    public String getInReplyToStatusIdString() {
+        return inReplyToStatusIdString;
+    }
+
+    @Override
     public long getInReplyToUserId() {
         return inReplyToUserId;
+    }
+
+    @Override
+    public String getInReplyToUserIdString() {
+        return inReplyToUserIdString;
     }
 
     @Override
@@ -402,6 +426,11 @@ import static twitter4j.ParseUtil.getDate;
     }
 
     @Override
+    public String getCurrentUserRetweetIdString() {
+        return currentUserRetweetIdString;
+    }
+
+    @Override
     public boolean isPossiblySensitive() {
         return isPossiblySensitive;
     }
@@ -444,6 +473,11 @@ import static twitter4j.ParseUtil.getDate;
     @Override
     public long getQuotedStatusId() {
         return quotedStatusId;
+    }
+
+    @Override
+    public String getQuotedStatusIdString() {
+        return quotedStatusIdString;
     }
 
     @Override

--- a/twitter4j-core/src/internal-json/java/twitter4j/StatusJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/StatusJSONImpl.java
@@ -20,6 +20,7 @@ import static twitter4j.ParseUtil.getDate;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Objects;
 
 import twitter4j.conf.Configuration;
 
@@ -34,16 +35,13 @@ import twitter4j.conf.Configuration;
 
     private Date createdAt;
     private long id;
-    private String idString;
     private String text;
     private int displayTextRangeStart = -1;
     private int displayTextRangeEnd = -1;
     private String source;
     private boolean isTruncated;
     private long inReplyToStatusId;
-    private String inReplyToStatusIdString;
     private long inReplyToUserId;
-    private String inReplyToUserIdString;
     private boolean isFavorited;
     private boolean isRetweeted;
     private int favoriteCount;
@@ -64,13 +62,11 @@ import twitter4j.conf.Configuration;
     private MediaEntity[] mediaEntities;
     private SymbolEntity[] symbolEntities;
     private long currentUserRetweetId = -1L;
-    private String currentUserRetweetIdString = "-1";
     private Scopes scopes;
     private User user = null;
     private String[] withheldInCountries = null;
     private Status quotedStatus;
     private long quotedStatusId = -1L;
-    private String quotedStatusIdString = "-1";
 
     /*package*/StatusJSONImpl(HttpResponse res, Configuration conf) throws TwitterException {
         super(res);
@@ -102,14 +98,11 @@ import twitter4j.conf.Configuration;
 
     private void init(JSONObject json) throws TwitterException {
         id = ParseUtil.getLong("id", json);
-        idString = ParseUtil.getUnescapedString("id", json);
         source = ParseUtil.getUnescapedString("source", json);
         createdAt = getDate("created_at", json);
         isTruncated = ParseUtil.getBoolean("truncated", json);
         inReplyToStatusId = ParseUtil.getLong("in_reply_to_status_id", json);
-        inReplyToStatusIdString = ParseUtil.getUnescapedString("in_reply_to_status_id", json);
         inReplyToUserId = ParseUtil.getLong("in_reply_to_user_id", json);
-        inReplyToUserIdString = ParseUtil.getUnescapedString("in_reply_to_user_id", json);
         isFavorited = ParseUtil.getBoolean("favorited", json);
         isRetweeted = ParseUtil.getBoolean("retweeted", json);
         inReplyToScreenName = ParseUtil.getUnescapedString("in_reply_to_screen_name", json);
@@ -145,7 +138,6 @@ import twitter4j.conf.Configuration;
             }
             if (!json.isNull("quoted_status_id")) {
                 quotedStatusId = ParseUtil.getLong("quoted_status_id", json);
-                quotedStatusIdString = ParseUtil.getUnescapedString("quoted_status_id", json);
             }
             if (!json.isNull("display_text_range")) {
                 JSONArray indicesArray = json.getJSONArray("display_text_range");
@@ -173,7 +165,6 @@ import twitter4j.conf.Configuration;
 
             if (!json.isNull("current_user_retweet")) {
                 currentUserRetweetId = json.getJSONObject("current_user_retweet").getLong("id");
-                currentUserRetweetIdString = json.getJSONObject("current_user_retweet").getString("id");
             }
             if (!json.isNull("lang")) {
                 lang = ParseUtil.getUnescapedString("lang", json);
@@ -310,8 +301,9 @@ import twitter4j.conf.Configuration;
         return this.id;
     }
 
+    @Override
     public String getIdString() {
-        return this.idString;
+        return Objects.toString(getId());
     }
 
     @Override
@@ -347,7 +339,7 @@ import twitter4j.conf.Configuration;
 
     @Override
     public String getInReplyToStatusIdString() {
-        return inReplyToStatusIdString;
+        return Objects.toString(getInReplyToStatusIdString(), "");
     }
 
     @Override
@@ -357,7 +349,7 @@ import twitter4j.conf.Configuration;
 
     @Override
     public String getInReplyToUserIdString() {
-        return inReplyToUserIdString;
+        return Objects.toString(getInReplyToUserIdString(), "");
     }
 
     @Override
@@ -427,7 +419,7 @@ import twitter4j.conf.Configuration;
 
     @Override
     public String getCurrentUserRetweetIdString() {
-        return currentUserRetweetIdString;
+        return Objects.toString(getCurrentUserRetweetIdString(), "");
     }
 
     @Override
@@ -477,7 +469,7 @@ import twitter4j.conf.Configuration;
 
     @Override
     public String getQuotedStatusIdString() {
-        return quotedStatusIdString;
+        return Objects.toString(getQuotedStatusIdString(), "");
     }
 
     @Override

--- a/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
@@ -18,6 +18,7 @@ package twitter4j;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Objects;
 
 import twitter4j.conf.Configuration;
 
@@ -30,7 +31,6 @@ import twitter4j.conf.Configuration;
 
     private static final long serialVersionUID = -5448266606847617015L;
     private long id;
-    private String idString;
     private String name;
     private String email;
     private String screenName;
@@ -99,7 +99,6 @@ import twitter4j.conf.Configuration;
     private void init(JSONObject json) throws TwitterException {
         try {
             id = ParseUtil.getLong("id", json);
-            idString = ParseUtil.getRawString("id", json);
             name = ParseUtil.getRawString("name", json);
             email = ParseUtil.getRawString("email", json);
             screenName = ParseUtil.getRawString("screen_name", json);
@@ -210,7 +209,7 @@ import twitter4j.conf.Configuration;
 
     @Override
     public String getIdString() {
-        return idString;
+        return Objects.toString(getId());
     }
 
     @Override

--- a/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/UserJSONImpl.java
@@ -16,10 +16,10 @@
 
 package twitter4j;
 
-import twitter4j.conf.Configuration;
-
 import java.util.Arrays;
 import java.util.Date;
+
+import twitter4j.conf.Configuration;
 
 /**
  * A data class representing Basic user information element
@@ -30,6 +30,7 @@ import java.util.Date;
 
     private static final long serialVersionUID = -5448266606847617015L;
     private long id;
+    private String idString;
     private String name;
     private String email;
     private String screenName;
@@ -98,6 +99,7 @@ import java.util.Date;
     private void init(JSONObject json) throws TwitterException {
         try {
             id = ParseUtil.getLong("id", json);
+            idString = ParseUtil.getRawString("id", json);
             name = ParseUtil.getRawString("name", json);
             email = ParseUtil.getRawString("email", json);
             screenName = ParseUtil.getRawString("screen_name", json);
@@ -204,6 +206,11 @@ import java.util.Date;
     @Override
     public long getId() {
         return id;
+    }
+
+    @Override
+    public String getIdString() {
+        return idString;
     }
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/Status.java
+++ b/twitter4j-core/src/main/java/twitter4j/Status.java
@@ -40,6 +40,7 @@ public interface Status extends Comparable<Status>, TwitterResponse,
      * @return the id (e.g. 210462857140252672)
      */
     long getId();
+    String getIdString();
 
     /**
      * Returns the text of the status
@@ -60,7 +61,6 @@ public interface Status extends Comparable<Status>, TwitterResponse,
      */
     String getSource();
 
-
     /**
      * Test if the status is truncated
      *
@@ -76,6 +76,7 @@ public interface Status extends Comparable<Status>, TwitterResponse,
      * @since Twitter4J 1.0.4
      */
     long getInReplyToStatusId();
+    String getInReplyToStatusIdString();
 
     /**
      * Returns the in_reply_user_id
@@ -84,6 +85,7 @@ public interface Status extends Comparable<Status>, TwitterResponse,
      * @since Twitter4J 1.0.4
      */
     long getInReplyToUserId();
+    String getInReplyToUserIdString();
 
     /**
      * Returns the in_reply_to_screen_name
@@ -186,6 +188,7 @@ public interface Status extends Comparable<Status>, TwitterResponse,
      * @since Twitter4J 3.0.1
      */
     long getCurrentUserRetweetId();
+    String getCurrentUserRetweetIdString();
 
     /**
      * Returns true if the status contains a link that is identified as sensitive.
@@ -226,6 +229,7 @@ public interface Status extends Comparable<Status>, TwitterResponse,
      * @since Twitter4J 4.0.4
      */
     long getQuotedStatusId();
+    String getQuotedStatusIdString();
 
     /**
      * Returns the Tweet object of the original Tweet that was quoted.

--- a/twitter4j-core/src/main/java/twitter4j/User.java
+++ b/twitter4j-core/src/main/java/twitter4j/User.java
@@ -30,6 +30,7 @@ public interface User extends Comparable<User>, TwitterResponse, java.io.Seriali
      * @return the id of the user
      */
     long getId();
+    String getIdString();
 
     /**
      * Returns the name of the user


### PR DESCRIPTION
This is a start to adding string fields for core status/user long fields. The value is JavaScript sometimes truncates long fields.

The Twitter API also seems to return a "_str" version for some field but this maintains consistency with how we've done things.