### PR TITLE
Chunked Uploads Cleanup and Improvements

### DIFF
--- a/twitter4j-core/src/internal-http/java/twitter4j/HttpClientImpl.java
+++ b/twitter4j-core/src/internal-http/java/twitter4j/HttpClientImpl.java
@@ -16,13 +16,22 @@
 
 package twitter4j;
 
-import twitter4j.conf.ConfigurationContext;
-
-import java.io.*;
-import java.net.*;
+import java.io.BufferedInputStream;
+import java.io.DataOutputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Authenticator;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import twitter4j.conf.ConfigurationContext;
 
 /**
  * @author Yusuke Yamamoto - yusuke at mac.com
@@ -141,7 +150,15 @@ class HttpClientImpl extends HttpClientBase implements HttpResponseCode, java.io
                         os.close();
                     }
                     res = new HttpResponseImpl(con, CONF);
-                    responseCode = con.getResponseCode();
+                    try {
+                        responseCode = con.getResponseCode();
+                    } catch (IOException codeIoException) {
+                        if (codeIoException.getMessage().contains("response code: 413")) {
+                            responseCode = 413;
+                        } else {
+                            throw codeIoException;
+                        }
+                    }
                     if (logger.isDebugEnabled()) {
                         logger.debug("Response: ");
                         Map<String, List<String>> responseHeaders = con.getHeaderFields();

--- a/twitter4j-core/src/internal-http/java/twitter4j/HttpResponseCode.java
+++ b/twitter4j-core/src/internal-http/java/twitter4j/HttpResponseCode.java
@@ -31,6 +31,7 @@ public interface HttpResponseCode {
     int NOT_FOUND = 404; // Not Found: The URI requested is invalid or the resource requested, such as a user, does not exists.
     int NOT_ACCEPTABLE = 406; // Not Acceptable: Returned by the Search API when an invalid format is specified in the request.
     int GONE = 410; // Gone: Used to indicate that an API endpoint has been turned off.
+    int ENTITY_TOO_LARGE = 413; // Undocumented response code returned during media upload when the file included is too large.
     int ENHANCE_YOUR_CALM = 420; // Enhance Your Calm: Returned by the Search and Trends API  when you are being rate limited. Not registered in RFC.
     int UNPROCESSABLE_ENTITY = 422; //Returned when an image uploaded to POST account/update_profile_banner is unable to be processed.
     int TOO_MANY_REQUESTS = 429; //Returned in API v1.1 when a request cannot be served due to the application's rate limit having been exhausted for the resource. See Rate Limiting in API v1.1.

--- a/twitter4j-core/src/internal-http/java/twitter4j/HttpResponseImpl.java
+++ b/twitter4j-core/src/internal-http/java/twitter4j/HttpResponseImpl.java
@@ -39,9 +39,13 @@ public class HttpResponseImpl extends HttpResponse {
            *
            * This causes an IOException in the getResponseCode() method call. See https://dev.twitter.com/issues/1114
            * This call can, however, me made a second time without exception.
+           *
+           * Twitter also throws an IOException for a 413 code, which is a valid (but undocumented) response code when a large entity is included
            */
             if ("Received authentication challenge is null".equals(e.getMessage())) {
                 this.statusCode = con.getResponseCode();
+            } else if (e.getMessage().contains("response code: 413")) {
+                this.statusCode = 413;
             } else {
                 throw e;
             }

--- a/twitter4j-core/src/internal-http/java/twitter4j/HttpResponseImpl.java
+++ b/twitter4j-core/src/internal-http/java/twitter4j/HttpResponseImpl.java
@@ -39,13 +39,9 @@ public class HttpResponseImpl extends HttpResponse {
            *
            * This causes an IOException in the getResponseCode() method call. See https://dev.twitter.com/issues/1114
            * This call can, however, me made a second time without exception.
-           *
-           * Twitter also throws an IOException for a 413 code, which is a valid (but undocumented) response code when a large entity is included
            */
             if ("Received authentication challenge is null".equals(e.getMessage())) {
                 this.statusCode = con.getResponseCode();
-            } else if (e.getMessage().contains("response code: 413")) {
-                this.statusCode = 413;
             } else {
                 throw e;
             }

--- a/twitter4j-core/src/main/java/twitter4j/TwitterException.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterException.java
@@ -43,7 +43,6 @@ public class TwitterException extends Exception implements TwitterResponse, Http
         this(message, (Throwable) null);
     }
 
-
     public TwitterException(Exception cause) {
         this(cause.getMessage(), cause);
         if (cause instanceof TwitterException) {
@@ -62,14 +61,18 @@ public class TwitterException extends Exception implements TwitterResponse, Http
         this.statusCode = statusCode;
     }
 
+    public TwitterException(String message, int errorCode) {
+        this(message);
+        this.errorMessage = message;
+        this.errorCode = errorCode;
+    }
+
     @Override
     public String getMessage() {
         StringBuilder value = new StringBuilder();
         if (errorMessage != null && errorCode != -1) {
-            value.append("message - ").append(errorMessage)
-                    .append("\n");
-            value.append("code - ").append(errorCode)
-                    .append("\n");
+            value.append("message - ").append(errorMessage).append("\n");
+            value.append("code - ").append(errorCode).append("\n");
         } else {
             value.append(super.getMessage());
         }
@@ -305,6 +308,9 @@ public class TwitterException extends Exception implements TwitterResponse, Http
                 break;
             case GONE:
                 cause = "This API endpoint has been turned off.";
+                break;
+            case ENTITY_TOO_LARGE:
+                cause = "The request sent to Twitter was too large. This most commonly occurs when an uploaded image or file is over Twitter's limit.";
                 break;
             case ENHANCE_YOUR_CALM:
                 cause = "Twitter rate limited the application (\"Enhance Your Calm\"). Rate Limit information: https://developer.twitter.com/en/docs/basics/rate-limiting.html -- https://developer.twitter.com/en/docs/basics/rate-limits";

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -133,7 +133,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
   }
 
-    /* Timelines Resources */
+  /* Timelines Resources */
 
   @Override
   public ResponseList<Status> getMentionsTimeline() throws TwitterException {
@@ -220,7 +220,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     ));
   }
 
-    /* Tweets Resources */
+  /* Tweets Resources */
 
   @Override
   public ResponseList<Status> getRetweets(long statusId) throws TwitterException {
@@ -344,12 +344,10 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
   private UploadedMedia uploadMediaChunkedInit(long size, String mimeType, TweetMediaType tweetMediaType) throws TwitterException {
     return new UploadedMedia(
         post(conf.getUploadBaseURL() + "media/upload.json",
-          new HttpParameter[]{
-              new HttpParameter("command", CHUNKED_INIT),
-              new HttpParameter("media_type", mimeType),
-              new HttpParameter("media_category", tweetMediaType.getTwitterKey()),
-              new HttpParameter("total_bytes", size)
-          }
+          new HttpParameter("command", CHUNKED_INIT),
+          new HttpParameter("media_type", mimeType),
+          new HttpParameter("media_category", tweetMediaType.getTwitterKey()),
+          new HttpParameter("total_bytes", size)
         ).asJSONObject());
   }
 
@@ -359,12 +357,10 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
                                         int segmentIndex,
                                         long mediaId) throws TwitterException {
     post(conf.getUploadBaseURL() + "media/upload.json",
-        new HttpParameter[]{
-          new HttpParameter("command", CHUNKED_APPEND),
-          new HttpParameter("media_id", mediaId),
-          new HttpParameter("segment_index", segmentIndex),
-          new HttpParameter("media", fileName, media)
-        }
+      new HttpParameter("command", CHUNKED_APPEND),
+      new HttpParameter("media_id", mediaId),
+      new HttpParameter("segment_index", segmentIndex),
+      new HttpParameter("media", fileName, media)
     );
   }
 
@@ -388,7 +384,14 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
 
       String state = stateMaybe.get();
       if (state.equals("failed")) {
-        throw new TwitterException("Failed to finalize the chunked upload.");
+        String errorReason = !uploadedMedia.getUploadErrorDisplay().isEmpty() ? uploadedMedia.getUploadErrorDisplay() : "No reason was parsed.";
+        String errorMessage = String.format("Failed to finalize the chunked upload. Reason: %s", errorReason);
+        Optional<Integer> uploadErrorCodeMaybe = uploadedMedia.getUploadErrorCode();
+        if (uploadErrorCodeMaybe.isPresent()) {
+          throw new TwitterException(errorMessage, uploadErrorCodeMaybe.get());
+        } else {
+          throw new TwitterException(errorMessage);
+        }
       }
       if (state.equals("pending") || state.equals("in_progress")) {
         currentProgressPercent = uploadedMedia.getProgressPercent().orElseThrow(() -> new TwitterException("Chunked upload API response had no progress percentage."));
@@ -397,7 +400,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
         try {
           Thread.sleep(waitSec * 1000);
         } catch (InterruptedException e) {
-          throw new TwitterException("Failed to finalize the chunked upload.", e);
+          throw new TwitterException("Failed to finalize the chunked upload. Upload was interrupted.", e);
         }
       }
       if (state.equals("succeeded")) {
@@ -411,9 +414,8 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
   private UploadedMedia uploadMediaChunkedFinalize0(long mediaId) throws TwitterException {
     JSONObject json = post(
         conf.getUploadBaseURL() + "media/upload.json",
-        new HttpParameter[]{
-            new HttpParameter("command", CHUNKED_FINALIZE),
-            new HttpParameter("media_id", mediaId)})
+        new HttpParameter("command", CHUNKED_FINALIZE),
+        new HttpParameter("media_id", mediaId))
         .asJSONObject();
     logger.debug("Finalize response:" + json);
     return new UploadedMedia(json);
@@ -422,15 +424,14 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
   private UploadedMedia uploadMediaChunkedStatus(long mediaId) throws TwitterException {
     JSONObject json = get(
         conf.getUploadBaseURL() + "media/upload.json",
-        new HttpParameter[]{
-            new HttpParameter("command", CHUNKED_STATUS),
-            new HttpParameter("media_id", mediaId)})
+        new HttpParameter("command", CHUNKED_STATUS),
+        new HttpParameter("media_id", mediaId))
         .asJSONObject();
     logger.debug("Status response:" + json);
     return new UploadedMedia(json);
   }
     
-    /* Search Resources */
+  /* Search Resources */
 
   @Override
   public QueryResult search(Query query) throws TwitterException {
@@ -443,7 +444,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
   }
 
-    /* Direct Messages Resources */
+  /* Direct Messages Resources */
 
   @Override
   public ResponseList<DirectMessage> getDirectMessages() throws TwitterException {
@@ -501,7 +502,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     return get(url).asStream();
   }
 
-    /* Friends & Followers Resources */
+  /* Friends & Followers Resources */
 
   @Override
   public IDs getNoRetweetsFriendships() throws TwitterException {
@@ -765,7 +766,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
         new HttpParameter("include_user_entities", includeUserEntities)));
   }
 
-    /* Users Resources */
+  /* Users Resources */
 
   @Override
   public AccountSettings getAccountSettings() throws TwitterException {
@@ -1051,7 +1052,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
         , new HttpParameter("banner", "banner", image));
   }
 
-    /* Suggested Users Resources */
+  /* Suggested Users Resources */
 
   @Override
   public ResponseList<User> getUserSuggestions(String categorySlug) throws TwitterException {
@@ -1080,7 +1081,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     return factory.createUserListFromJSONArray(res);
   }
 
-    /* Favorites Resources */
+  /* Favorites Resources */
 
   @Override
   public ResponseList<Status> getFavorites() throws TwitterException {
@@ -1129,7 +1130,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     return factory.createStatus(post(conf.getRestBaseURL() + "favorites/create.json?id=" + id));
   }
 
-    /* Lists Resources */
+  /* Lists Resources */
 
   @Override
   public ResponseList<UserList> getUserLists(String listOwnerScreenName) throws TwitterException {
@@ -1798,7 +1799,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
         , new HttpParameter("cursor", cursor)));
   }
 
-    /* Saved Searches Resources */
+  /* Saved Searches Resources */
 
   @Override
   public ResponseList<SavedSearch> getSavedSearches() throws TwitterException {
@@ -1823,7 +1824,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
         + "saved_searches/destroy/" + id + ".json"));
   }
 
-    /* Places & Geo Resources */
+  /* Places & Geo Resources */
 
   @Override
   public Place getGeoDetails(String placeId) throws TwitterException {
@@ -1870,7 +1871,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
         + "geo/similar_places.json", params.toArray(new HttpParameter[params.size()])));
   }
 
-    /* Trends Resources */
+  /* Trends Resources */
 
   @Override
   public Trends getPlaceTrends(int woeid) throws TwitterException {
@@ -1892,7 +1893,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
         , new HttpParameter("long", location.getLongitude())));
   }
 
-    /* Spam Reporting Resources */
+  /* Spam Reporting Resources */
 
   @Override
   public User reportSpam(long userId) throws TwitterException {
@@ -1908,7 +1909,7 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     ));
   }
 
-    /* Help Resources */
+  /* Help Resources */
 
   @Override
   public TwitterAPIConfiguration getAPIConfiguration() throws TwitterException {

--- a/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
@@ -192,7 +192,8 @@ public interface TweetsResources {
     
     /**
      * Uploads media using chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}. 
-     * This should be used for videos.
+     * This should be used for videos, images, or animated gifs.
+     * This method uploads the entire file into memory. For a buffered approach, see {@link #uploadMediaChunkedBuffered)}.
      * <br>This method calls https://api.twitter.com/1.1/media/upload.json
      *
      * @param fileName media file name
@@ -207,4 +208,25 @@ public interface TweetsResources {
      * @since HubSpot/Twitter4J 4.0.8
      */
     UploadedMedia uploadMediaChunked(String fileName, InputStream media, String mimeType, TweetMediaType tweetMediaType) throws TwitterException;
+
+    /**
+     * Uploads media using chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
+     * This should be used for videos, images, or animated gifs.
+     * This method does a buffered read of the input stream. For a faster, in-memory approach, see {@link #uploadMediaChunked)}.
+     * <br>This method calls https://api.twitter.com/1.1/media/upload.json
+     *
+     * @param fileName media file name
+     * @param media media body as stream
+     * @param mimeType e.g. MIME type (aka media_type) of media (e.g. video/mp4)
+     * @param tweetMediaType generally IMAGE or VIDEO. Enables advanced features like tracking video duration.
+     * @param mediaLengthBytes file size in bytes of the full, uploaded image/video.
+     *
+     * @return upload result
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/rest/public/uploading-media#chunkedupload">Uploading Media | Twitter Developers</a>
+     * @see <a href="https://dev.twitter.com/docs/api/1.1/post/statuses/update">POST statuses/update | Twitter Developers</a>
+     * @see <a href="https://dev.twitter.com/docs/api/multiple-media-extended-entities">Multiple Media Entities in Statuses</a>
+     * @since HubSpot/Twitter4J 4.0.8
+     */
+    UploadedMedia uploadMediaChunkedBuffered(String fileName, InputStream media, String mimeType, TweetMediaType tweetMediaType, long mediaLengthBytes) throws TwitterException;
 }


### PR DESCRIPTION
A few updates:

1) Added `uploadMediaChunkedBuffered`, which streams the inputStream file vs putting it in memory.
2) More detailed TwitterExceptions when a chunked upload fails.
3) Handle 413 "Entity Too Large" exceptions in the standard way.
4) Assorted cleanup, comments, and renaming.