### PR TITLE
Bump from 4.0.10 to 4.0.11 and allow manual status checking for chunked upload

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -42,4 +42,4 @@ paragraph = With Twitter4J, you can easily integrate your Java application with 
 version = 4  # This must be parsable as an int
 
 # The version as the user will see it. If blank, the version attribute will be used here
-prettyVersion = 4.0.10  # This is treated as a String
+prettyVersion = 4.0.11  # This is treated as a String

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.twitter4j</groupId>
   <artifactId>twitter4j</artifactId>
-  <version>4.0.10-hubspot-SNAPSHOT</version>
+  <version>4.0.11-hubspot-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>twitter4j</name>
   <description>A Java library for the Twitter API</description>
   <url>http://twitter4j.org/</url>
 
   <properties>
-    <hubspot.twitter4j.current.version>4.0.10-hubspot-SNAPSHOT</hubspot.twitter4j.current.version>
+    <hubspot.twitter4j.current.version>4.0.11-hubspot-SNAPSHOT</hubspot.twitter4j.current.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/twitter4j-appengine/pom.xml
+++ b/twitter4j-appengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j</artifactId>
-    <version>4.0.10-hubspot-SNAPSHOT</version>
+    <version>4.0.11-hubspot-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter4j-appengine</artifactId>

--- a/twitter4j-appengine/src/main/java/twitter4j/VersionAppEngine.java
+++ b/twitter4j-appengine/src/main/java/twitter4j/VersionAppEngine.java
@@ -21,7 +21,7 @@ package twitter4j;
  * @since Twitter4J 2.2.4
  */
 public final class VersionAppEngine {
-    private static final String VERSION = "4.0.10";
+    private static final String VERSION = "4.0.11";
     private static final String TITLE = "Twitter4J App Engine Support";
 
     private VersionAppEngine() {

--- a/twitter4j-async/pom.xml
+++ b/twitter4j-async/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j</artifactId>
-    <version>4.0.10-hubspot-SNAPSHOT</version>
+    <version>4.0.11-hubspot-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter4j-async</artifactId>

--- a/twitter4j-async/src/main/java/twitter4j/VersionAsync.java
+++ b/twitter4j-async/src/main/java/twitter4j/VersionAsync.java
@@ -20,7 +20,7 @@ package twitter4j;
  * @author Yusuke Yamamoto - yusuke at mac.com
  */
 public final class VersionAsync {
-    private static final String VERSION = "4.0.10";
+    private static final String VERSION = "4.0.11";
     private static final String TITLE = "Twitter4J Async API";
 
     private VersionAsync() {

--- a/twitter4j-core/pom.xml
+++ b/twitter4j-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j</artifactId>
-    <version>4.0.10-hubspot-SNAPSHOT</version>
+    <version>4.0.11-hubspot-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter4j-core</artifactId>

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -504,6 +504,11 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     logger.debug("Status response:" + json);
     return new UploadedMedia(json);
   }
+
+  @Override
+  public UploadedMedia uploadMediaChunkedGetStatus(long mediaId) throws TwitterException {
+    return uploadMediaChunkedStatus(mediaId);
+  }
     
   /* Search Resources */
 

--- a/twitter4j-core/src/main/java/twitter4j/Version.java
+++ b/twitter4j-core/src/main/java/twitter4j/Version.java
@@ -20,7 +20,7 @@ package twitter4j;
  * @author Yusuke Yamamoto - yusuke at mac.com
  */
 public final class Version {
-    private static final String VERSION = "4.0.10";
+    private static final String VERSION = "4.0.11";
     private static final String TITLE = "Twitter4J";
 
     private Version() {

--- a/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
@@ -191,10 +191,22 @@ public interface TweetsResources {
     UploadedMedia uploadMedia(String fileName, InputStream media) throws TwitterException;
 
     /**
+     * This should be called after {@link #uploadMediaChunked} or {@link #uploadMediaChunkedBuffered} to confirm the upload succeeded.
+     * To avoid manual status checking use {@link #uploadMediaChunkedAndConfirm} or {@link #uploadMediaChunkedBufferedAndConfirm}.
+     *
+     * @param mediaId ID of previously uploaded and finalized UploadedMedia object
+     * @return upload result
+     * @throws TwitterException assorted uploading errors or when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-upload">Uploading Media | Twitter Developers</a>
+     * @since HubSpot/Twitter4J 4.0.11
+     */
+    UploadedMedia uploadMediaChunkedGetStatus(long mediaId) throws TwitterException;
+
+    /**
      * Uploads media using a chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
      * This should be used for videos, images, or animated gifs.
-     * This method uploads the entire file into memory. For a buffered approach, see {@link #uploadMediaChunkedBuffered)}.
-     * <br>This method calls https://api.twitter.com/1.1/media/upload.json
+     * This method uploads the entire file into memory. For a buffered approach, see {@link #uploadMediaChunkedBuffered}.
+     * {@link #uploadMediaChunkedGetStatus} should be called after completion to confirm Twitter processed the upload.
      *
      * @param fileName media file name
      * @param media media body as stream
@@ -211,7 +223,7 @@ public interface TweetsResources {
     /**
      * Uploads media using a chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
      * This should be used for videos, images, or animated gifs.
-     * This method uploads the entire file into memory. For a buffered approach, see {@link #uploadMediaChunkedBuffered)}.
+     * This method uploads the entire file into memory. For a buffered approach, see {@link #uploadMediaChunkedBufferedAndConfirm}.
      * This method also checks the status to confirm the upload succeeded. To implement your own status-checking, see {@link #uploadMediaChunked)}.
      *
      * @param fileName media file name
@@ -230,6 +242,7 @@ public interface TweetsResources {
      * Uploads media using a chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
      * This should be used for videos, images, or animated gifs.
      * This method does a buffered read of the input stream. For an in-memory approach, see {@link #uploadMediaChunked)}.
+     * {@link #uploadMediaChunkedGetStatus} should be called after completion to confirm Twitter processed the upload.
      *
      * @param fileName media file name
      * @param media media body as stream
@@ -248,8 +261,8 @@ public interface TweetsResources {
     /**
      * Uploads media using a chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
      * This should be used for videos, images, or animated gifs.
-     * This method does a buffered read of the input stream. For an in-memory approach, see {@link #uploadMediaChunked)}.
-     * This method also checks the status to confirm the upload succeeded. To implement your own status-checking, see {@link #uploadMediaChunkedBuffered)}.
+     * This method does a buffered read of the input stream. For an in-memory approach, see {@link #uploadMediaChunkedAndConfirm)}.
+     * This method also checks the status to confirm the upload succeeded. To implement your own status-checking, see {@link #uploadMediaChunkedBuffered}.
      *
      * @param fileName media file name
      * @param media media body as stream

--- a/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/TweetsResources.java
@@ -189,9 +189,9 @@ public interface TweetsResources {
      * @since Twitter4J 4.0.3
      */
     UploadedMedia uploadMedia(String fileName, InputStream media) throws TwitterException;
-    
+
     /**
-     * Uploads media using chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}. 
+     * Uploads media using a chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
      * This should be used for videos, images, or animated gifs.
      * This method uploads the entire file into memory. For a buffered approach, see {@link #uploadMediaChunkedBuffered)}.
      * <br>This method calls https://api.twitter.com/1.1/media/upload.json
@@ -201,19 +201,35 @@ public interface TweetsResources {
      * @param mimeType e.g. MIME type (aka media_type) of media (e.g. video/mp4)
      * @param tweetMediaType generally IMAGE or VIDEO. Enables advanced features like tracking video duration.
      * @return upload result
-     * @throws TwitterException when Twitter service or network is unavailable
-     * @see <a href="https://dev.twitter.com/rest/public/uploading-media#chunkedupload">Uploading Media | Twitter Developers</a>
-     * @see <a href="https://dev.twitter.com/docs/api/1.1/post/statuses/update">POST statuses/update | Twitter Developers</a>
-     * @see <a href="https://dev.twitter.com/docs/api/multiple-media-extended-entities">Multiple Media Entities in Statuses</a>
+     * @throws TwitterException assorted uploading errors or when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-upload">Uploading Media | Twitter Developers</a>
+     * @see <a href="https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update.html">POST statuses/update | Twitter Developers</a>
      * @since HubSpot/Twitter4J 4.0.8
      */
     UploadedMedia uploadMediaChunked(String fileName, InputStream media, String mimeType, TweetMediaType tweetMediaType) throws TwitterException;
 
     /**
-     * Uploads media using chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
+     * Uploads media using a chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
      * This should be used for videos, images, or animated gifs.
-     * This method does a buffered read of the input stream. For a faster, in-memory approach, see {@link #uploadMediaChunked)}.
-     * <br>This method calls https://api.twitter.com/1.1/media/upload.json
+     * This method uploads the entire file into memory. For a buffered approach, see {@link #uploadMediaChunkedBuffered)}.
+     * This method also checks the status to confirm the upload succeeded. To implement your own status-checking, see {@link #uploadMediaChunked)}.
+     *
+     * @param fileName media file name
+     * @param media media body as stream
+     * @param mimeType e.g. MIME type (aka media_type) of media (e.g. video/mp4)
+     * @param tweetMediaType generally IMAGE or VIDEO. Enables advanced features like tracking video duration.
+     * @return upload result
+     * @throws TwitterException assorted uploading errors or when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-upload">Uploading Media | Twitter Developers</a>
+     * @see <a href="https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update.html">POST statuses/update | Twitter Developers</a>
+     * @since HubSpot/Twitter4J 4.0.11
+     */
+    UploadedMedia uploadMediaChunkedAndConfirm(String fileName, InputStream media, String mimeType, TweetMediaType tweetMediaType) throws TwitterException;
+
+    /**
+     * Uploads media using a chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
+     * This should be used for videos, images, or animated gifs.
+     * This method does a buffered read of the input stream. For an in-memory approach, see {@link #uploadMediaChunked)}.
      *
      * @param fileName media file name
      * @param media media body as stream
@@ -222,11 +238,30 @@ public interface TweetsResources {
      * @param mediaLengthBytes file size in bytes of the full, uploaded image/video.
      *
      * @return upload result
-     * @throws TwitterException when Twitter service or network is unavailable
-     * @see <a href="https://dev.twitter.com/rest/public/uploading-media#chunkedupload">Uploading Media | Twitter Developers</a>
-     * @see <a href="https://dev.twitter.com/docs/api/1.1/post/statuses/update">POST statuses/update | Twitter Developers</a>
-     * @see <a href="https://dev.twitter.com/docs/api/multiple-media-extended-entities">Multiple Media Entities in Statuses</a>
+     * @throws TwitterException assorted uploading errors or when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-upload">Uploading Media | Twitter Developers</a>
+     * @see <a href="https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update.html">POST statuses/update | Twitter Developers</a>
      * @since HubSpot/Twitter4J 4.0.8
      */
     UploadedMedia uploadMediaChunkedBuffered(String fileName, InputStream media, String mimeType, TweetMediaType tweetMediaType, long mediaLengthBytes) throws TwitterException;
+
+    /**
+     * Uploads media using a chunked approach to be attached via {@link #updateStatus(twitter4j.StatusUpdate)}.
+     * This should be used for videos, images, or animated gifs.
+     * This method does a buffered read of the input stream. For an in-memory approach, see {@link #uploadMediaChunked)}.
+     * This method also checks the status to confirm the upload succeeded. To implement your own status-checking, see {@link #uploadMediaChunkedBuffered)}.
+     *
+     * @param fileName media file name
+     * @param media media body as stream
+     * @param mimeType e.g. MIME type (aka media_type) of media (e.g. video/mp4)
+     * @param tweetMediaType generally IMAGE or VIDEO. Enables advanced features like tracking video duration.
+     * @param mediaLengthBytes file size in bytes of the full, uploaded image/video.
+     *
+     * @return upload result
+     * @throws TwitterException assorted uploading errors or when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-upload">Uploading Media | Twitter Developers</a>
+     * @see <a href="https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update.html">POST statuses/update | Twitter Developers</a>
+     * @since HubSpot/Twitter4J 4.0.11
+     */
+    UploadedMedia uploadMediaChunkedBufferedAndConfirm(String fileName, InputStream media, String mimeType, TweetMediaType tweetMediaType, long mediaLengthBytes) throws TwitterException;
 }

--- a/twitter4j-examples/pom.xml
+++ b/twitter4j-examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j</artifactId>
-    <version>4.0.10-hubspot-SNAPSHOT</version>
+    <version>4.0.11-hubspot-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter4j-examples</artifactId>

--- a/twitter4j-examples/src/main/java/twitter4j/examples/ExamplesVersion.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/ExamplesVersion.java
@@ -20,7 +20,7 @@ package twitter4j.examples;
  * @author Yusuke Yamamoto - yusuke at mac.com
  */
 public final class ExamplesVersion {
-    private static final String VERSION = "4.0.10";
+    private static final String VERSION = "4.0.11";
     private static final String TITLE = "Twitter4J examples";
 
     private ExamplesVersion() {

--- a/twitter4j-http2-support/pom.xml
+++ b/twitter4j-http2-support/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j</artifactId>
-    <version>4.0.10-hubspot-SNAPSHOT</version>
+    <version>4.0.11-hubspot-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter4j-http2-support</artifactId>

--- a/twitter4j-http2-support/src/main/java/twitter4j/VersionHTTP2.java
+++ b/twitter4j-http2-support/src/main/java/twitter4j/VersionHTTP2.java
@@ -21,7 +21,7 @@ package twitter4j;
  * @since Twitter4J 3.0.6
  */
 public final class VersionHTTP2 {
-    private static final String VERSION = "4.0.10";
+    private static final String VERSION = "4.0.11";
     private static final String TITLE = "Twitter4J HTTP/2 Support";
 
     private VersionHTTP2() {

--- a/twitter4j-media-support/pom.xml
+++ b/twitter4j-media-support/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j</artifactId>
-    <version>4.0.10-hubspot-SNAPSHOT</version>
+    <version>4.0.11-hubspot-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter4j-media-support</artifactId>

--- a/twitter4j-media-support/src/main/java/twitter4j/media/Version.java
+++ b/twitter4j-media-support/src/main/java/twitter4j/media/Version.java
@@ -20,7 +20,7 @@ package twitter4j.media;
  * @author Yusuke Yamamoto - yusuke at mac.com
  */
 public final class Version {
-    private static final String VERSION = "4.0.10";
+    private static final String VERSION = "4.0.11";
     private static final String TITLE = "Twitter4J Media support";
 
     private Version() {

--- a/twitter4j-stream/pom.xml
+++ b/twitter4j-stream/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j</artifactId>
-    <version>4.0.10-hubspot-SNAPSHOT</version>
+    <version>4.0.11-hubspot-SNAPSHOT</version>
   </parent>
 
   <artifactId>twitter4j-stream</artifactId>

--- a/twitter4j-stream/src/main/java/twitter4j/VersionStream.java
+++ b/twitter4j-stream/src/main/java/twitter4j/VersionStream.java
@@ -20,7 +20,7 @@ package twitter4j;
  * @author Yusuke Yamamoto - yusuke at mac.com
  */
 public final class VersionStream {
-    private static final String VERSION = "4.0.10";
+    private static final String VERSION = "4.0.11";
     private static final String TITLE = "Twitter4J Streaming API support";
 
     private VersionStream() {


### PR DESCRIPTION
This changes `chunkedUpload` and `chunkedUploadBuffered` to no longer do status checking at the end while adding `andConfirm` methods that still maintain the same behavior.

This was motivated by wanting to allow more custom, flexible status checking and trying to prevent slow uploads that stall even after 20 status checks.