### PR TITLE
add TwitterExceptionErrorCode static factory methods

### DIFF
--- a/twitter4j-core/src/main/java/twitter4j/TwitterExceptionErrorCode.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterExceptionErrorCode.java
@@ -1,6 +1,10 @@
 package twitter4j;
 
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * https://developer.twitter.com/en/docs/basics/response-codes
@@ -55,6 +59,8 @@ public enum TwitterExceptionErrorCode {
   INVALID_ATTACHMENT_TYPE_QUANTITY(386, Optional.of(HttpResponseCode.FORBIDDEN)),
   INVALID_URL(407, Optional.of(HttpResponseCode.BAD_REQUEST));
 
+  private static final Map<Integer, TwitterExceptionErrorCode> TWITTER_EXCEPTION_ERROR_CODES_BY_INTEGER_ERROR_CODE = Arrays.asList(values()).stream()
+      .collect(Collectors.toMap(TwitterExceptionErrorCode::getCode, Function.identity()));
   private final int code;
   private final Optional<Integer> associatedStatusCode;
 
@@ -71,4 +77,12 @@ public enum TwitterExceptionErrorCode {
     return associatedStatusCode;
   }
 
+  public static Optional<TwitterExceptionErrorCode> tryParseFromErrorCode(int errorCode) {
+    return Optional.ofNullable(TWITTER_EXCEPTION_ERROR_CODES_BY_INTEGER_ERROR_CODE.get(errorCode));
+  }
+
+  public static TwitterExceptionErrorCode parseFromErrorCode(int errorCode) {
+    return tryParseFromErrorCode(errorCode)
+        .orElseThrow(() -> new IllegalArgumentException(String.format("%s is not a valid Twitter error code", errorCode)));
+  }
 }


### PR DESCRIPTION
this will let clients take TwitterExceptons and convert them easily into
TwitterExceptionErrorCode instances.

I've created two different static factory methods: one returns an
Optional value which will be empty if we encounter an unknown status
code. The other throws an IllegalArgumentException if the error code
isn't known.

Generally, I prefer the IllegalArgumentException approach, as it fails
quickly on invalid input. Since Twitter could change their exception
codes at any time though, I think the Optional-returning method is safer
for clients.